### PR TITLE
Do not unset EASYRSA_OPENSSL after completing the test

### DIFF
--- a/easyrsa-unit-tests.sh
+++ b/easyrsa-unit-tests.sh
@@ -1127,7 +1127,7 @@ create_pki ()
 		[ "$EASYRSA_USE_PASS" ] && print && print "* Use Passwords!" && print
 		unset NEW_PKI
 		unset STAGE_NAME
-		unset EASYRSA_OPENSSL
+		#unset EASYRSA_OPENSSL
 	else
 		vdisabled "$STAGE_NAME"
 	fi


### PR DESCRIPTION
This corrects the final output of the SSL library in use.

Signed-off-by: Richard T Bonhomme <tincantech@protonmail.com>