### PR TITLE
Update 'help' commands

### DIFF
--- a/easyrsa-unit-tests-help.sh
+++ b/easyrsa-unit-tests-help.sh
@@ -1019,10 +1019,6 @@ run_help_commands ()
 	action
 
 	newline 1
-	STEP_NAME="help renewable"
-	action
-
-	newline 1
 	STEP_NAME="help rewind-renew"
 	action
 


### PR DESCRIPTION
Remove 'renewable' - Removed from Easy-RSA

Change 'set-rsa-pass' to 'set-ed-pass'
set-pass has replaced all set-X-pass commands, or will do soon.

Signed-off-by: Richard T Bonhomme <tincantech@protonmail.com>