### PR TITLE
Disable build-ca with default method

### DIFF
--- a/easyrsa-unit-tests.sh
+++ b/easyrsa-unit-tests.sh
@@ -64,7 +64,7 @@ init ()
 	ERSA_OUT="${ERSA_OUT:-0}"
 	ACT_OUT="$TEMP_DIR/.act.out"
 	ACT_ERR="$TEMP_DIR/.act.err"
-	TEST_BUILD_CA_DEFAULT_METHOD=1
+	#TEST_BUILD_CA_DEFAULT_METHOD=1
 
 	# Setup the 'easyrsa' executable to use
 		# In PATH


### PR DESCRIPTION
This allows removing hard-coded unit-test password from EasyRSA.

Signed-off-by: Richard T Bonhomme <tincantech@protonmail.com>